### PR TITLE
Modified upstrap function to accept a vector of new sample sizes instead of number of grid points and min and max multiplier

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: upstrap
-Title: Upstrap: Oversampling Data for Sample Size Calculation
-Version: 0.1.0
+Title: Upstrap: Oversampling or Undersampling Data
+Version: 1.0.0
 Authors@R: 
     c(
     person(given = "Ciprian",
@@ -12,11 +12,15 @@ Authors@R:
            family = "Muschelli",
            role = c("aut"),
            email = "muschellij2@gmail.com",
-           comment = c(ORCID = "0000-0001-6469-1750"))
+           comment = c(ORCID = "0000-0001-6469-1750")),
+    person(given = "Adina",
+           family = "Crainiceanu",
+           role = c("aut"),
+           email = "adina@usna.edu")
            )           
-Description: The upstrap resamples data with a sample size
-    larger than the original sample size.  This method allows users to see
-    behavior of estimators in increasing sample sizes, commonly done for
+Description: The upstrap resamples with replacement data with a sample size
+    smaller or larger than the original sample size.  This method allows users to see
+    behavior of estimators in different sample sizes, commonly done for
     sample size calculation.
 License: GPL-3
 Suggests: 

--- a/R/upstrapExampleSampleSizeCalculation.R
+++ b/R/upstrapExampleSampleSizeCalculation.R
@@ -1,0 +1,126 @@
+#' Upstrap example for sample size calculation
+#' Using a subset of the Sleep Heart Health Study data provided in this package, 
+#' for a given value of beta (say, 0.1 or 0.2), what is the sample size that
+#' will ensure that the null hypothesis of zero main effect of HTN will be rejected
+#' with a frequency at least equal to 100(1-beta)% (power)?
+#' 
+#' @return none
+#' @export
+#'
+#' @examples
+#' upstrapExampleSampleSizeCalculation()
+upstrapExampleSampleSizeCalculation = function() {
+  
+  fname = system.file("extdata", "shhs1.txt",
+                      package = "upstrap")
+  # read in the data
+  dat = read.table(file = fname,
+                   header = TRUE, na.strings="NA")
+  
+  # show the head of the list `dat`
+  head(dat)
+  
+  # show the dimension of the list
+  dim(dat)
+  
+  # to explore the data, do a scatterplot of the Body Mass Index (BMI) versus Respiratory Disturbance Index (RDI),
+  # variables labeled `bmi_s1` and `rdi4p`, respectively.
+  # The figure below provides the scatter plot of BMI versus RDI, though, for presentation purposes,
+  # we only show RDI less than 50.
+  plot(dat$bmi_s1,dat$rdi4p,pch=".",col=rgb(0,0,1,.2),cex=3,ylim=c(0,50),bty="l",
+       cex.axis=1.2,col.axis="blue",main=NULL,xlab="Body Mass Index",
+       ylab="Respiratory Disturbance Index (4%)")
+  points(mean(dat$bmi_s1,na.rm=TRUE),mean(dat$rdi4p,na.rm=TRUE),cex=2,pch=19,col=rgb(1,0,0,0.5))
+  
+  # calculate the mean BMI and RDI
+  round(mean(dat$bmi_s1,na.rm=TRUE),digits=2)
+  round(mean(dat$rdi4p,na.rm=TRUE),digits=2)
+  
+  ## Fit a basic regression model
+  # define the moderate to severe sleep apnea variable from rdi4p
+  MtS_SA=dat$rdi4p>=15
+  
+  # add the MtS_SA variable to the data frame
+  dat$MtS_SA=MtS_SA
+  
+  # identify how many individuals in SHHS (visit 1) have moderate
+  # to severe sleep apnea
+  n_positive =sum(MtS_SA)
+  n_positive
+  
+  # conduct a binary GLM regression with outcome moderate to severe
+  # sleep apnea (Yes=1, No=0) on a few covariates (main effects)
+  # and an interaction (age by HTN)
+  fit<-glm(MtS_SA~gender+age_s1+bmi_s1+HTNDerv_s1+age_s1*HTNDerv_s1,
+           family="binomial",data=dat)
+  summary(fit)
+  
+  # answer the question:
+  # For a given value of beta (say, 0.1 or 0.2), what is the sample size that
+  # will ensure that the null hypothesis of zero main effect of HTN will be rejected
+  # with a frequency at least equal to 100(1-beta)% (power)?
+  
+  ## The upstrap for sample size calculation
+  
+  # set the seed for reproducibility
+  set.seed(08132018)
+  
+  # sample size of the original data
+  n_oss=dim(dat)[1]
+  
+  # number of grid points for the multiplier of the sample size
+  n_grid_multiplier=21
+  
+  # minimum and maximum multiplier for the sample size
+  # here they are set to 1 (same sample size) and 5 (5 times the original sample size)
+  min_multiplier=1
+  max_multiplier=5
+  
+  # set the grid of multipliers for the original sample size
+  # here 1.2 stands for a sampel size that is 20% larger than the original sample size
+  multiplier_grid=seq(from=min_multiplier, to=max_multiplier,length=n_grid_multiplier)
+  
+  # vector of the new sample sizes
+  new_sample_sizes = n_oss * multiplier_grid
+  
+  # set the number of upstraps for each grid point;
+  # this impacts running time and variability of the sample size calculation:
+  # more data points, more running time, less variability
+  # 10000 can take about 7-8 hours on a typical laptop
+  # decrease this number for faster results
+  n_upstrap=100
+  
+  # define statistic function to compute the estimate we are interested in 
+  statistic = function(data) {
+    fit <- glm(MtS_SA~gender+age_s1+bmi_s1+HTNDerv_s1+age_s1*HTNDerv_s1, 
+               family="binomial", 
+               data=data)
+    # could use broom
+    #  tid = broom::tidy(fit)
+    #  pval = tid$p.value[ tid$term == "HTNDerv_s1"]
+    smod <- coef(summary(fit))
+    pval <- smod["HTNDerv_s1", "Pr(>|z|)"]
+    pval < 0.05
+  }
+  
+  # invoke upstap for each new sample size
+  check = upstrap(dat, statistic = statistic, 
+                  R = n_upstrap, 
+                  new_sample_size = new_sample_sizes)
+  
+  
+  # power check calculates the proportion of times the null hypothesis is rejected
+  power_check = colMeans(check)
+  
+  # plot the vector of multipliers of the original sample size, versus the power curve for
+  # rejecting the null hypothesis that the parameter of HTN is equal to zero
+  plot(multiplier_grid,power_check,type="l",col="blue",lwd=3,
+       xlab="Factor by which the sample size is multiplied",
+       ylab="Power to detect the HTN effect",
+       bty="l",cex.axis=1.5,cex.lab=1.4,col.lab="blue",
+       col.axis="blue",main=NULL)
+  # add horizontal lines to indicate power equal to 0.8 (orange) and 0.9 (red).
+  abline(h=0.8,lwd=3,col="orange")
+  abline(h=0.9,lwd=3,col="red")
+  
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -9,10 +9,9 @@
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 # upstrap
-Materials accompanying the upstrap paper including vignette (.Rmd, .pdf, .html), Sleep Heart Health Study (SHHS) data, 
-and figure used for the vignette
+Materials accompanying the upstrap paper including vignette (.Rmd, .pdf, .html), Sleep Heart Health Study (SHHS) data, code,  and figure used for the vignette
 
-An R package called upstrap and additional code will be added as it becomes available
+An R package called upstrap is also available
 
 ```{r setup, include = FALSE}
 knitr::opts_chunk$set(
@@ -22,7 +21,8 @@ knitr::opts_chunk$set(
 )
 ```
 # upstrap Package: 
-The goal of `upstrap` is to provide the upstrap resamples data with a sample size larger than the original sample size.  This method allows users to see behavior of estimators in increasing sample sizes, commonly done for sample size calculation.
+The goal of `upstrap` is to provide the upstrap functionality. The upstrap resamples data with a sample size smaller or larger than the original sample size.  This method allows users to see behavior of estimators in different sample sizes, commonly done for sample size calculation.
+
 
 ## Installation
 
@@ -30,7 +30,7 @@ You can install `upstrap` from GitHub with:
 
 ```{r gh-installation, eval = FALSE}
 # install.packages("remotes")
-remotes::install_github("muschellij2/upstrap")
+remotes::install_github("ccrainic/upstrap")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,24 @@
 
-[![Travis build
-status](https://travis-ci.com/muschellij2/upstrap.svg?branch=master)](https://travis-ci.com/muschellij2/upstrap)
-[![AppVeyor Build
-Status](https://ci.appveyor.com/api/projects/status/github/muschellij2/upstrap?branch=master&svg=true)](https://ci.appveyor.com/project/muschellij2/upstrap)
-[![Coverage
-status](https://codecov.io/gh/muschellij2/upstrap/branch/master/graph/badge.svg)](https://codecov.io/gh/muschellij2/upstrap)
-<!-- README.md is generated from README.Rmd. Please edit that file -->
+[![Travis build status](https://travis-ci.com/muschellij2/upstrap.svg?branch=master)](https://travis-ci.com/muschellij2/upstrap) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/muschellij2/upstrap?branch=master&svg=true)](https://ci.appveyor.com/project/muschellij2/upstrap) [![Coverage status](https://codecov.io/gh/muschellij2/upstrap/branch/master/graph/badge.svg)](https://codecov.io/gh/muschellij2/upstrap) <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# upstrap
+upstrap
+=======
 
-Materials accompanying the upstrap paper including vignette (.Rmd, .pdf,
-.html), Sleep Heart Health Study (SHHS) data, and figure used for the
-vignette
+Materials accompanying the upstrap paper including vignette (.Rmd, .pdf, .html), Sleep Heart Health Study (SHHS) data, code, and figure used for the vignette
 
-An R package called upstrap and additional code will be added as it
-becomes available
+An R package called upstrap is also available
 
-# upstrap Package:
+upstrap Package:
+================
 
-The goal of `upstrap` is to provide the upstrap resamples data with a
-sample size larger than the original sample size. This method allows
-users to see behavior of estimators in increasing sample sizes, commonly
-done for sample size calculation.
+The goal of `upstrap` is to provide the upstrap functionality. The upstrap resamples data with a sample size smaller or larger than the original sample size. This method allows users to see behavior of estimators in different sample sizes, commonly done for sample size calculation.
 
-## Installation
+Installation
+------------
 
 You can install `upstrap` from GitHub with:
 
 ``` r
 # install.packages("remotes")
-remotes::install_github("muschellij2/upstrap")
+remotes::install_github("ccrainic/upstrap")
 ```

--- a/man/upstrap.Rd
+++ b/man/upstrap.Rd
@@ -4,54 +4,66 @@
 \alias{upstrap}
 \title{Upstrap Resampling}
 \usage{
-upstrap(data, statistic, R = 10000, n.grid.multiplier = 21,
-  range_multiplier = c(1, 5), ...)
+upstrap(data, statistic, R, new_sample_size, ...)
 }
 \arguments{
-\item{data}{The data as a matrix or data frame.
+\item{data}{The data as a vector, matrix, or data frame.
 If it is a matrix or data frame then each row
 is considered as one multivariate observation.}
 
-\item{statistic}{A function which when applied to data returns a vector
-containing the statistic(s) of interest.}
+\item{statistic}{A function which when applied to data returns a value
+containing the statistic of interest.}
 
-\item{R}{The number of upstrap replicates for each point on the grid of
-range multipliers. Usually this will be a single positive integer.}
+\item{R}{The number of upstrap replicates for each value in
+new_sample_size vector. This should be a single positive integer.}
 
-\item{n.grid.multiplier}{number of grid points for the
-multiplier of the sample size.}
-
-\item{range_multiplier}{minimum and maximum multiplier for the sample size}
+\item{new_sample_size}{A vector of one or more new sample sizes,
+to be drawn from the orignal data set. The new sample sizes can be less than,
+equal to, or larger than the original data set.}
 
 \item{...}{additional arguments to pass to \code{statistic}.}
 }
 \value{
-An object
+matrix of R replicates of the statistic applied to
+the upstrap data. One column for each value in new_sample_size
 }
 \description{
-Upstrap Resampling
+This function samples with replacement either more or fewer
+samples than the original sample size
 }
 \examples{
+# read in the data
 fname = system.file("extdata", "shhs1.txt",
 package = "upstrap")
-# read in the data
 data = read.table(file = fname,
                  header = TRUE, na.strings="NA")
+# define the moderate to severe sleep apnea variable
+# from rdi4p - Respiratory Disturbance Index (RDI)
 data$MtS_SA = data$rdi4p>=15
+
+#define statistic function
 statistic = function(data) {
 fit<-glm(MtS_SA ~ gender + age_s1 + bmi_s1 +
-HTNDerv_s1 + age_s1*HTNDerv_s1, family="binomial", data=data)
-# could use broom
-#  tid = broom::tidy(fit)
-#  pval = tid$p.value[ tid$term == "HTNDerv_s1"]
+ HTNDerv_s1 + age_s1*HTNDerv_s1,
+ family="binomial",
+ data=data)
+
 smod = coef(summary(fit))
 pval = smod["HTNDerv_s1", "Pr(>|z|)"]
 pval < 0.05
 }
+
+# do upstrap for the same sample size, 1.5 the original size
+# and twice the original size
 res = upstrap(data,
-statistic = statistic,
-R = 50,
-n.grid.multiplier = 1,
-range_multiplier = c(1, 2))
-res = colMeans(res)
+  statistic = statistic,
+  R = 50,
+  new_sample_size = c(nrow(data), nrow(data)\\*1.5, nrow(data)\\*2))
+
+# display results
+power_res = colMeans(res)
+
 }
+\keyword{bootstrap,}
+\keyword{resampling}
+\keyword{upstrap,}

--- a/vignettes/upstrap_vignette.Rmd
+++ b/vignettes/upstrap_vignette.Rmd
@@ -12,7 +12,7 @@ vignette: >
 knitr::opts_chunk$set(echo = TRUE)
 ```
 
-This is a vignette associated with the paper "The upstrap". Just like the bootstrap, the upstrap uses sampling with replacement of the original data to estimate the variability of various estimators (a.k.a. functions  of the data). In contrast to the bootstrap, the upstrap uses a number of resamples that can be smaller than, equal to, or larger than the original sample size of the data; the bootstrap uses only a number of samples equal to the sample size of the original data. This substantially extends the number and variety of scenarios where the variability of estimators can be evaluated using computational tools. For example, the upstrap could be used to assess the low and moderate sample size behavior of estimators via subsampling with replacement. Also, it can be used for sample size calculations that take into account the variability in effect estimation. To illustrate this latter point, this vignette provides an example on how to conduct the upstrap when we are interested in sample size calculations in a regression context. This document is designed to make the paper fully reproducible, while an `R` (R Development Core Team, 2008) package called `upstrap` will be deployed at the same GitHub address. The vignette will be improved, as software is updated and examples are added. The code is presented in extended format for pedagogical purposes, but the code can be substantially reduced using the (still in development) `upstrap` package in `R`. 
+This is a vignette associated with the paper "The upstrap". Just like the bootstrap, the upstrap uses sampling with replacement of the original data to estimate the variability of various estimators (a.k.a. functions  of the data). In contrast to the bootstrap, the upstrap uses a number of resamples that can be smaller than, equal to, or larger than the original sample size of the data; the bootstrap uses only a number of samples equal to the sample size of the original data. This substantially extends the number and variety of scenarios where the variability of estimators can be evaluated using computational tools. For example, the upstrap could be used to assess the low and moderate sample size behavior of estimators via subsampling with replacement. Also, it can be used for sample size calculations that take into account the variability in effect estimation. To illustrate this latter point, this vignette provides an example on how to conduct the upstrap when we are interested in sample size calculations in a regression context. This document is designed to make the paper fully reproducible, while an `R` (R Development Core Team, 2008) package called `upstrap` will be deployed at the same GitHub address. The vignette will be improved, as software is updated and examples are added. The code is presented in extended format for pedagogical purposes, but the code can be substantially reduced using the `upstrap` package in `R`. 
 
 
 To do this, we will use a subset of the Sleep Heart Health Study (SHHS), a multicenter study on sleep-disordered breathing, hypertension, and cardiovascular disease (Dean et al. 2016, Quan et al. 1997, Redline et al. 1998). The SHHS drew on the resources of existing, well-characterized, epidemiologic cohorts, and conducted further data collection, including measurements of sleep and breathing. The complete SHHS dataset is available online as part of the National Sleep Research Resource [https://sleepdata.org/datasets](https://sleepdata.org/datasets). For the purpose of this vignette we consider a small subset of the variables from the visit $1$ of the SHHS. We use `R` for computation and visualization. 
@@ -126,10 +126,14 @@ min.multiplier=1
 max.multiplier=5
 
 # set the grid of multipliers for the original sample size
-# here 1.2 stands for a sampel size that is 20% larger than the original sample size
+# here 1.2 stands for a sample size that is 20% larger than the original sample size
 multiplier.grid=seq(from=min.multiplier, to=max.multiplier,length=n.grid.multiplier)
 
+# vector of the new sample sizes
+new.sample.sizes = n.oss * multiplier.grid
+
 # set the number of upstraps for each grid point
+# higher the number, lower the variability, but higher the computation time
 n.upstrap=10000
 ```
 
@@ -169,8 +173,8 @@ for (j in 1:n.grid.multiplier)
 }
 ```
 
-Using the `upstrap` function, we can do this with a much shorter bit of code.  We first need to define the `statistic`, which a function to calculate the estimate of interest.  We will then set the number of upstrap resamples per grid to be much smaller and a much smaller search grid so that we can see how this performs in a short period of time.
-```{r}
+Using the `upstrap` function, we can do this with a shorter bit of code.  We first need to define the `statistic`, which is a function to calculate the estimate of interest. We then invoke the upstrap function, passing the dataset, the statistic function, the number of upstraps, and the vector of sample sizes. 
+```{r,eval=FALSE}
 library(upstrap)
 statistic <- function(data) {
   fit <- glm(MtS_SA ~ gender + age_s1 + bmi_s1 +
@@ -182,17 +186,16 @@ statistic <- function(data) {
   pval <- smod["HTNDerv_s1", "Pr(>|z|)"]
   pval < 0.05
 }
-res <- upstrap(dat, statistic = statistic, 
-               R = 100, n.grid.multiplier = 5,
-              range_multiplier = c(1, 3))
+check <- upstrap(dat, statistic = statistic, 
+               R = n.upstrap, 
+               new_sample_size = new.sample.sizes)
 ```
 
-Once the matrix `check` of dimensions `n.upstrap` by `n.grid.multiplier` is obtained we calculate its column means. This results in a vector of length `n.grid.multiplier`, which contains the proportion of times out of `n.upstrap` samples when the null hypothesis that the parameter of HTN is equal to zero is rejected. This is the power curve as a function of the multiplier of the original sample size.
+Once the matrix `check` of dimensions `n.upstrap` by `n.grid.multiplier` is obtained, we calculate its column means. This results in a vector of length `n.grid.multiplier`, which contains the proportion of times out of `n.upstrap` samples when the null hypothesis that the parameter of HTN is equal to zero is rejected. This is the power curve as a function of the multiplier of the original sample size.
 
 ```{r,eval=FALSE}
 # power check calculates the proportion of times the null hypothesis is rejected
 power_check<-colMeans(check)
-res <- colMeans(res)
 ```
 
 Below we plot the vector of multipliers of the original sample size, `n.grid.multiplier`, versus the power curve for rejecting the null hypothesis that the parameter of HTN is equal to zero, `power_check`. Horizontal lines are shown to indicate power equal to $0.8$ (orange) and $0.9$ (red). The value  $1$ on the $x$-axis corresponds to a sample size equal to the original sample size. The corresponding value on the $y$-axis on the curve is the boostrap p-value, or the frequency with which the null hypothesis that the HTN effect is zero is rejected using the bootstrap. The value $1.2$ on the $x$-axis corresponds to a sample size $20$\% larger than the original sample size. The corresponding value on the $y$-axis on the curve is the upstrap p-value, or the frequency with which the null hypothesis that the HTN effect is zero is rejected using the upstrap with a sample size multiplier equal to $1.2$.


### PR DESCRIPTION
Modified upstrap function to accept a vector of new sample sizes instead of number of grid points and min and max multiplier. The new API easily allow a user to specify what sample size(s) is desired, making it more similar with the boot API 